### PR TITLE
fix for ID and Thumbnail search result

### DIFF
--- a/lib/src/model/search/id.dart
+++ b/lib/src/model/search/id.dart
@@ -9,8 +9,9 @@ class Id {
   final String kind;
   final String? videoId;
   final String? channelId;
+  final String? playlistId;
 
-  Id({required this.kind, this.videoId, this.channelId});
+  Id({required this.kind, this.videoId, this.channelId, this.playlistId});
 
   factory Id.fromJson(Map<String, dynamic> json) => _$IdFromJson(json);
 

--- a/lib/src/model/search/id.dart
+++ b/lib/src/model/search/id.dart
@@ -7,9 +7,10 @@ part 'id.g.dart';
 @JsonSerializable()
 class Id {
   final String kind;
-  final String videoId;
+  final String? videoId;
+  final String? channelId;
 
-  Id({required this.kind, required this.videoId});
+  Id({required this.kind, this.videoId, this.channelId});
 
   factory Id.fromJson(Map<String, dynamic> json) => _$IdFromJson(json);
 

--- a/lib/src/model/search/id.g.dart
+++ b/lib/src/model/search/id.g.dart
@@ -10,10 +10,12 @@ Id _$IdFromJson(Map<String, dynamic> json) => Id(
       kind: json['kind'] as String,
       videoId: json['videoId'] as String?,
       channelId: json['channelId'] as String?,
+      playlistId: json['playlistId'] as String?,
     );
 
 Map<String, dynamic> _$IdToJson(Id instance) => <String, dynamic>{
       'kind': instance.kind,
       'videoId': instance.videoId,
       'channelId': instance.channelId,
+      'playlistId': instance.playlistId,
     };

--- a/lib/src/model/search/id.g.dart
+++ b/lib/src/model/search/id.g.dart
@@ -8,10 +8,12 @@ part of 'id.dart';
 
 Id _$IdFromJson(Map<String, dynamic> json) => Id(
       kind: json['kind'] as String,
-      videoId: json['videoId'] as String,
+      videoId: json['videoId'] as String?,
+      channelId: json['channelId'] as String?,
     );
 
 Map<String, dynamic> _$IdToJson(Id instance) => <String, dynamic>{
       'kind': instance.kind,
       'videoId': instance.videoId,
+      'channelId': instance.channelId,
     };

--- a/lib/src/model/thumbnail.dart
+++ b/lib/src/model/thumbnail.dart
@@ -11,15 +11,15 @@ class Thumbnail {
   final String url;
 
   ///The image's width.
-  final int width;
+  final int? width;
 
   ///The image's height.
-  final int height;
+  final int? height;
 
   Thumbnail({
     required this.url,
-    required this.width,
-    required this.height,
+    this.width,
+    this.height,
   });
 
   factory Thumbnail.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/model/thumbnail.g.dart
+++ b/lib/src/model/thumbnail.g.dart
@@ -8,8 +8,8 @@ part of 'thumbnail.dart';
 
 Thumbnail _$ThumbnailFromJson(Map<String, dynamic> json) => Thumbnail(
       url: json['url'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
+      width: json['width'] as int?,
+      height: json['height'] as int?,
     );
 
 Map<String, dynamic> _$ThumbnailToJson(Thumbnail instance) => <String, dynamic>{


### PR DESCRIPTION
When searching for channel or playlists, the search results do not include a videoId but instead a channelId and playlistId. Also thumbnails do not include sizes.
To fix this videoId, channelId, playlistId and the width and height of thumbnails have been made optional.

I think this is the best fix without causing problems with backwards compatibility .